### PR TITLE
docs(github-template): fix typos and wording

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,7 +10,7 @@ assignees: ""
 <!-- A clear and concise description of what the bug is. -->
 
 ## {{ cookiecutter.project_name }} version
-<!-- x.y.z -->
+<!-- x.y.z or commit hash -->
 
 ## Steps to Reproduce
 <!--

--- a/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.md
+++ b/{{cookiecutter.project_slug}}/.github/ISSUE_TEMPLATE/documentation.md
@@ -7,7 +7,7 @@ assignees: ""
 ---
 
 ## Type
-* [ ] Conent inaccurate
+* [ ] Content inaccurate
 * [ ] Content missing
 * [ ] Typo
 

--- a/{{cookiecutter.project_slug}}/.github/pull_request_template.md
+++ b/{{cookiecutter.project_slug}}/.github/pull_request_template.md
@@ -32,7 +32,7 @@ Steps to reproduce the behavior:
 <!--A clear and concise description of what you expected to happen-->
 
 ## Related Issue
-<!--If applicable, refernce to the issue related to this pull request.-->
+<!--If applicable, reference to the issue related to this pull request.-->
 
 ## Additional context
 <!--Add any other context or screenshots about the pull request here.-->


### PR DESCRIPTION
Fix obvious typos. Fix wording because I think we may prefer using poetry instead of invoke now.

off-topic: this project itself does not use its own github template when the project is hosted on github