### PR TITLE
fix(tasks): run commands for installing pre-commit hooks sequentially

### DIFF
--- a/tasks/env.py
+++ b/tasks/env.py
@@ -20,11 +20,9 @@ def init(ctx):
 def setup_pre_commit_hook(ctx):
     """Setup pre-commit hook to automate check before git commit and git push"""
     ctx.run("git init")
-    ctx.run(
-        f"{VENV_PREFIX} pre-commit install -t pre-commit & "
-        f"{VENV_PREFIX}  pre-commit install -t pre-push & "
-        f"{VENV_PREFIX} pre-commit install -t commit-msg"
-    )
+    ctx.run(f"{VENV_PREFIX} pre-commit install -t pre-commit")
+    ctx.run(f"{VENV_PREFIX} pre-commit install -t pre-push")
+    ctx.run(f"{VENV_PREFIX} pre-commit install -t commit-msg")
 
 
 @task(optional=["no-pre-commit"])


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that do not apply to this change-->

- **Bugfix**
<img width="1053" alt="截圖 2021-01-23 下午12 35 01" src="https://user-images.githubusercontent.com/26277801/105569175-75e0eb80-5d7a-11eb-8f0b-1860754c00b3.png">


## Description
<!--Describe what the change is**-->
Make the commands for installing pre-commit hooks within python invoke tasks run sequentially to avoid deadlock.

### Environment
- macOS Catalina version 10.15.5
- git version 2.24.3 (Apple Git-128)

## Checklist:
- [x] Add test cases to all the changes you introduce
- [x] Run `inv lint` locally to ensure all linter checks pass
- [x] Run `inv test` locally to ensure all test cases pass
- [x] Run `inv secure` locally to ensure no major vulnerability is introduced
- [x] Update the documentation if necessary

## Steps to Test This Pull Request
1. run `poetry run inv env.setup-pre-commit-hook` should be successful without deadlock.

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
Pre-commit hooks were installed successfully.
<img width="1070" alt="截圖 2021-01-23 下午12 37 23" src="https://user-images.githubusercontent.com/26277801/105569217-c6584900-5d7a-11eb-86a9-3eed81e88e54.png">


## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
