### PR TITLE
fix(license): use correct BSD license name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,6 @@
     "dependency_management_tool": ["pipenv", "poetry"],
     "use_strict_mypy_config": "n",
     "build_pypi_package": "n",
-    "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
+    "open_source_license": ["MIT license", "BSD 3-Clause license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"],
     "_template_version": "0.7.1"
 }

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -20,9 +20,8 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.open_source_license == 'BSD license' %}
-
-BSD License
+{% elif cookiecutter.open_source_license == 'BSD 3-Clause license' %}
+BSD 3-Clause License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author_name }}
 All rights reserved.


### PR DESCRIPTION
The current content of BSD license is essentially the content of BSD "3-clause" license. The name "BSD license" is ambiguous because several variants of BSD license are also popular and available.