### PR TITLE
fix(cookiecutter.json): use https by default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
     "project_description": "Short Descirption for Python Project",
     "github_username": "Lee-W",
-    "github_url": "http://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}",
+    "github_url": "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}",
     "author_name": "Wei Lee",
     "author_email": "weilee.rx@gmail.com",
     "python_version": "3.7",


### PR DESCRIPTION
https should be encouraged to use if available. Besides, Github only supports https.