### PR TITLE
fix(template): update mypy version of pyproject.toml

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -114,7 +114,7 @@ coverage = {extras = ["toml"], version = "^5.0.4"}
 # style
 flake8 = "^3.7.9"
 pylint = "^2.4.4"
-mypy = "^0.770"
+mypy = "^0.800"
 black = "^19.10b0"
 isort = "^5.0.0"
 # security


### PR DESCRIPTION
mypy 0.770 is not compatible with python 3.9. The issue was fixed in
0.780 and 0.800 starts to support python 3.9 officially.

mypy issue 8614 and 8627
https://github.com/python/mypy/issues/8614
https://github.com/python/mypy/issues/8627