### PR TITLE
fix(template): typo of jinja2 minus and package name

### DIFF
--- a/{{cookiecutter.project_slug}}/docs/contributing.md
+++ b/{{cookiecutter.project_slug}}/docs/contributing.md
@@ -24,8 +24,7 @@ git checkout -b [YOUR FEATURE]
 
 ```sh
 python -m pip install pipx
-python -m pipx install {% if cookiecutter.dependency_management_tool == 'pipenv' -%}pipenv{%- elif cookiecutter.dependency_management_tool == 'poetry' -%}poetry{% endif -%} invoke
-python -m pipx ensurepath
+python -m pipx install {% if cookiecutter.dependency_management_tool == 'pipenv' -%}pipenv{%- elif cookiecutter.dependency_management_tool == 'poetry' -%}poetry{%- endif %} invoke
 ```
 
 * [pipx](https://github.com/pipxproject/pipx): for python tool management


### PR DESCRIPTION
"ensurepath" seems non-existent and also not used. Besides, the minus of endif should not remove the preceding space of invoke.