### PR TITLE
Using GITHUB_TOKEN instead of setting another one

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,8 +39,6 @@ cookiecutter https://github.com/Lee-W/cookiecutter-python-template
 ```
 
 * Add required secrets to your GitHub repository secrets
-    * `PERSONAL_ACCESS_TOKEN`: GitHub personal access toekn
-        * Refer to [Creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to generate one
     * `pypi_password`: PyPI API token
         * required only if you set "build_pypi_package" to "y" during project creation
         * Refer to [How can I use API tokens to authenticate with PyPI?](https://pypi.org/help/#apitoken) to generate one. Note that username `__token__` has been setup in the project

--- a/{{cookiecutter.project_slug}}/.github/workflows/{{cookiecutter.default_branch}}-updated.yaml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/{{cookiecutter.default_branch}}-updated.yaml
@@ -14,12 +14,12 @@ jobs:
       - name: Check out
         uses: actions/checkout@v2
         with:
-          token: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
+          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           fetch-depth: 0
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
-          github_token: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
+          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           branch: {{ cookiecutter.default_branch }}
 
   publish-github-page:
@@ -28,7 +28,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@main
         with:
-          token: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
+          token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           fetch-depth: 0
 
       - name: Set up Python {{ cookiecutter.python_version }}
@@ -48,6 +48,6 @@ jobs:
       - name: Push documentation to Github Page
         uses: peaceiris/actions-gh-pages@v3.8.0
         with:
-          personal_token: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
+          personal_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           publish_branch: gh-pages
           publish_dir: ./site


### PR DESCRIPTION
I opened this pull request for taking out the requirement of setting `PERSONAL_ACCESS_TOKEN` since GitHub Action [create a secret called `GITHUB_TOKEN` automatically](https://docs.github.com/en/actions/security-guides/automatic-token-authentication). The configuration for projects that use this template would be easier without creating another access token in repository. Please feel free to have a discussion on this PR. Thanks!