### PR TITLE
fix(workflows): change actions version

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/python-check.yaml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/python-check.yaml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python {{ cookiecutter.python_version }}
-        uses: actions/setup-python@4
+        uses: actions/setup-python@v5
         with:
           python-version: "{{ cookiecutter.python_version }}"
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/python-publish.yaml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/python-publish.yaml
@@ -9,10 +9,10 @@ jobs:
   publish-pypi-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@m4
+        uses: actions/setup-python@v5
         with:
           python-version: "{{ cookiecutter.python_version }}"
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/{{cookiecutter.default_branch}}-updated.yaml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/{{cookiecutter.default_branch}}-updated.yaml
@@ -12,7 +12,7 @@ jobs:
     name: "Bump version and create changelog with commitizen"
     steps:
       - name: Check out
-        uses: actions/checkout@4
+        uses: actions/checkout@v4
         with:
           token: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
           fetch-depth: 0
@@ -28,13 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@4
+        uses: actions/checkout@v4
         with:
           token: {% raw %}${{ secrets.PERSONAL_ACCESS_TOKEN }}{% endraw %}
           fetch-depth: 0
 
       - name: Set up Python {{ cookiecutter.python_version }}
-        uses: actions/setup-python@4
+        uses: actions/setup-python@v5
         with:
           python-version: "{{ cookiecutter.python_version }}"
 


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**

## Description

<img width="816" alt="Screenshot 2024-02-17 at 1 18 53 PM" src="https://github.com/Lee-W/cookiecutter-python-template/assets/4927361/da35a4ba-01f5-450e-a7b8-43dfa4e80362">

There is no https://github.com/actions/checkout/tree/4/ and https://github.com/actions/setup-python/tree/4/.


* change actions/checkout@4 to actions/checkout@v4
* change actions/setup-python@4 to actions/setup-python@v5

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [X] Run `inv style` locally to ensure all linter checks pass
- [X] Run `inv test` locally to ensure all test cases pass
- [X] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
